### PR TITLE
Update library to adafruit-circuitpython-dht

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
-prometheus_client
-Adafruit_DHT
-ConfigArgParse
+Adafruit-Blinka==6.20.1
+adafruit-circuitpython-dht==3.7.0
+Adafruit-PlatformDetect==3.19.4
+Adafruit-PureIO==1.1.9
+prometheus-client==0.13.1
+pyftdi==0.53.3
+pyserial==3.5
+pyusb==1.2.1
+RPi.GPIO==0.7.0


### PR DESCRIPTION
First of all, thanks for the exporter!

I've noticed that this repo uses [Adafruit_Python_DHT](https://github.com/adafruit/Adafruit_Python_DHT) library, which marked as obsoleted and archived.

This PR introduces [Adafruit_CircuitPython_DHT](https://github.com/adafruit/Adafruit_CircuitPython_DHT) library. Which counted as successor.

Tested on RPi 4B.
